### PR TITLE
Fix regular expression

### DIFF
--- a/plantuml.py
+++ b/plantuml.py
@@ -62,7 +62,7 @@ from markdown.util import etree, AtomicString
 # For details see https://pythonhosted.org/Markdown/extensions/api.html#blockparser
 class PlantUMLBlockProcessor(markdown.blockprocessors.BlockProcessor):
     # Regular expression inspired by the codehilite Markdown plugin
-    RE = re.compile(r'''```.*\n\s*::uml::
+    RE = re.compile(r'''\s*::uml::
                         \s*(format=(?P<quot>"|')(?P<format>\w+)(?P=quot))?
                         \s*(classes=(?P<quot1>"|')(?P<classes>[\w\s]+)(?P=quot1))?
                         \s*(alt=(?P<quot2>"|')(?P<alt>[\w\s"']+)(?P=quot2))?


### PR DESCRIPTION
In v1.1.0, the syntax is broken by https://github.com/mikitex70/plantuml-markdown/commit/7e10328e20a843a4f22ebebd243a8ffee7aa2933 .

Three backticks are required at the beginning like the following.

````
```
::uml:: format="png" classes="uml myDiagram" alt="My super diagram"
  Goofy ->  MickeyMouse: calls
  Goofy <-- MickeyMouse: responds
::end-uml::
````

I removed them because it is confusing with code blocks.

Please tell me if you have any reasons for three backticks.