### PR TITLE
Fix an error with svg format

### DIFF
--- a/plantuml.py
+++ b/plantuml.py
@@ -104,7 +104,6 @@ class PlantUMLBlockProcessor(markdown.blockprocessors.BlockProcessor):
             img = etree.SubElement(p, 'img')
             img.attrib['src'] = data
         elif imgformat == 'svg':
-            diagram = re.sub(r"^.*\n", "", diagram)
             # Firefox handles only base64 encoded SVGs
             data = 'data:image/svg+xml;base64,{0}'.format(
                 base64.b64encode(diagram).decode('ascii')


### PR DESCRIPTION
Fix an error with SVG format and python3.

The deleted line causes an error like the following.

```
TypeError: cannot use a string pattern on a bytes-like object
```

And the replacement seems not to be necessary with the latest PlantUML, 1.2017.13.