### PR TITLE
Fix rendering in indented blocks

### DIFF
--- a/plantuml_markdown.py
+++ b/plantuml_markdown.py
@@ -85,11 +85,11 @@ class PlantUMLPreprocessor(markdown.preprocessors.Preprocessor):
         \s*(height=(?P<quot5>"|')(?P<height>[\w\s"']+%?)(?P=quot5))?
         \s*\n
         (?P<code>.*?)(?<=\n)
-        ::end-uml::[ ]*$
+        \s*::end-uml::[ ]*$
         ''', re.MULTILINE | re.DOTALL | re.VERBOSE)
 
     FENCED_BLOCK_RE = re.compile(r'''
-        (?P<fence>^(?:~{3,}|`{3,}))[ ]*         # Opening ``` or ~~~
+        (?P<fence>(?:~{3,}|`{3,}))[ ]*          # Opening ``` or ~~~
         (\{?\.?(plant)?uml)[ ]*                 # Optional {, and lang
         # args
         \s*(format=(?P<quot>"|')(?P<format>\w+)(?P=quot))?
@@ -101,7 +101,7 @@ class PlantUMLPreprocessor(markdown.preprocessors.Preprocessor):
         [ ]*
         }?[ ]*\n                                # Optional closing }
         (?P<code>.*?)(?<=\n)
-        (?P=fence)[ ]*$
+        \s*(?P=fence)[ ]*$
         ''', re.MULTILINE | re.DOTALL | re.VERBOSE)
 
     def __init__(self, md):


### PR DESCRIPTION
It fixes issue #31 with rendering indented fenced blocks. They were
rendered only when put at beginning of the line. To illustrate, this
block was processed correctly

    ```plantuml
    A --> B : I am processed
    ```

while a block nested under a list item (indented) was not processed

      * A list item with nested block

        ```plantuml
        A --> B : I am not processed
        ```

With this patch the block is converted into image and correctly put in
the document tree allowing for images nested in other block elements,
e.g. list items.