### PR TITLE
Fix progression of parser

### DIFF
--- a/plantuml_markdown.py
+++ b/plantuml_markdown.py
@@ -230,7 +230,7 @@ class PlantUMLPreprocessor(markdown.preprocessors.Preprocessor):
 
         diag_tag = etree.tostring(img, short_empty_elements=self_closed).decode()
         return text[:m.start()] + m.group('indent') + diag_tag + text[m.end():], \
-               len(diag_tag) - len(text) + m.end()
+               m.start() + len(m.group('indent')) + len(diag_tag)
 
     def _render_diagram(self, code, requested_format):
         cached_diagram_file = None


### PR DESCRIPTION
In the current version, the calculation for how far the parser should progress through the content has a bug. In larger documents (and for some reason when using SVGs in particular), the parser will skip over large chunks of the content and leave diagrams un-rendered.

I can't share the source document and I haven't yet been able to create a reasonably sized test case to reproduce the issue. However, I've only able to confirm the changes by:

- With current version: Printing the text at the location of `idx` after it is updated. Confirmed suspicion that the pointer is arbitrarily jumping around in the document
- With fix: Pointer now appears to progress to the point right after the parsed text as expected

Let me know if I am missing something, but I think this fix is fairly straightforward.