### PR TITLE
There is no need to install uuid since Python 2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Markdown
 plantuml
-uuid


### PR DESCRIPTION
```
File "venv/lib/python3.8/site-packages/plantuml_markdown.py", line 67, in <module>
import uuid
File "venv/lib/python3.8/site-packages/uuid.py", line 138
if not 0 <= time_low < 1<<32L:
SyntaxError: invalid syntax
```
If venv has higher priority than global -> it leads to an Error (uuid installed was last time updated in 2006). 
UUID package is already included in Python