### PR TITLE
Remove md_globals kwarg

### DIFF
--- a/plantuml_markdown.py
+++ b/plantuml_markdown.py
@@ -346,7 +346,7 @@ class PlantUMLMarkdownExtension(markdown.Extension):
 
         super(PlantUMLMarkdownExtension, self).__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals=None):
+    def extendMarkdown(self, md):
         blockprocessor = PlantUMLPreprocessor(md)
         blockprocessor.config = self.getConfigs()
         # need to go before both fenced_code_block and things like retext's PosMapMarkPreprocessor.


### PR DESCRIPTION
Markdown 3.4 dropped support for the md_globals
kwarg:

https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/release-3.4.md#previously-deprecated-objects-have-been-removed

Closes #67