### PR TITLE
Explicitly pass charset to plantuml

### DIFF
--- a/plantuml_markdown.py
+++ b/plantuml_markdown.py
@@ -424,7 +424,7 @@ class PlantUMLPreprocessor(markdown.preprocessors.Preprocessor):
     @staticmethod
     def _render_local_uml_image(plantuml_code: str, img_format: str) -> Tuple[Optional[bytes], Optional[str]]:
         plantuml_code = plantuml_code.encode('utf8')
-        cmdline = ['plantuml', '-pipemap' if img_format == 'map' else '-p', "-t" + img_format]
+        cmdline = ['plantuml', '-pipemap' if img_format == 'map' else '-p', "-t" + img_format, '-charset', 'UTF-8']
 
         try:
             # On Windows run batch files through a shell so the extension can be resolved


### PR DESCRIPTION
The PlantUML code is explicitly encoded to UTF-8, but plantuml gets to pick its own charset. On my Windows installation it picks codepage 1252 by default, leading to wrong characters in the output. UTF-8 should be available everywhere according to the [PlantUML documentation](https://plantuml.com/unicode).