### PR TITLE
chore: add source tarball with requirements.txt at the root, for publishing to pypi

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,15 @@
 # Build package for Python 3
 . .env3*/bin/activate
 pip install setuptools twine wheel
-python setup.py bdist_wheel
+
+python setup.py bdist_wheel sdist --formats tar
+pushd dist >/dev/null || exit
+    distrib=$(ls *.tar); distrib=${distrib/.tar/}
+    mkdir -p ${distrib}
+        cp ../requirements.txt ${distrib}
+        tar rvf ${distrib}.tar ${distrib}/requirements.txt && gzip ${distrib}.tar
+    rm -fr ${distrib}
+popd >/dev/null || exit
 
 # Check that packages are ok
 twine check dist/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Markdown
+Markdown==3.4.1
 requests
 six

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'test-requirements.txt')) as f:
 
 setuptools.setup(
     name="plantuml-markdown",
-    version="3.9.2",
+    version="3.9.3",
     author="Michele Tessaro",
     author_email="michele.tessaro@email.it",
     description="A PlantUML plugin for Markdown",


### PR DESCRIPTION
chore: add source tarball with requirements.txt at the root, for publishing to https://pypi.org/project/plantuml-markdown/#files

Signed-off-by: Nick Boldt <nboldt@redhat.com>