### PR TITLE
change packaging style to avoid having to do copying on installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,7 @@ To use the plugin with [Python-Markdown][] you have the following options.  Plea
     >>> choco install plantuml
     ```
     (__Note__: This command will install all dependencies, Java and Graphviz included, see [https://chocolatey.org/packages/plantuml](https://chocolatey.org/packages/plantuml) for details.)
-1. Copy the file `./plantuml-markdown.py` into the `extensions` folder of [Python-Markdown][]. For example, for Python 2.7, you must do:
-    ```console
-    $ sudo cp plantuml-markdown.py /usr/lib/python27/site-packages/markdown/extensions/
-    ```
-1. Copy the file somewhere in your home. A good choice may be the `user-site` path.  For example, on Linux using `bash`:
-   ```console
-   $ export INSTALLPATH="`python -m site --user-site`/plantuml-markdown"
-   $ mkdir -p "$INSTALLPATH"
-   $ cp plantuml-markdown.py "$INSTALLPATH/mdx_plantuml-markdown.py"
-   $ export PYTHONPATH="${PYTHONPATH}:${INSTALLPATH}"
-    ```
-  You must export `PYTHONPATH` before running `markdown_py`, or you can put the definition in a bash config file (eg - `~/.bashrc`), then restart the terminal or use `source ~/.bashrc` or `. ~/.bashrc` to update the variable without closing the terminal.
+
 
 After the package is installed, you can use this plugin by activating it in the `markdown_py` command. For example:
   ```console
@@ -296,6 +285,7 @@ If you are getting strange behaviours in conjunction with other plugins, you can
 try to avoid the conflict, letting the plugin run before (higher value) or after other plugins (lower value).
 
 As an example of possible conflicts see issue [#38](https://github.com/mikitex70/plantuml-markdown/issues/38).
+
 
 Running tests
 -------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
       args:
         - MARKDOWN_VER=${MARKDOWN_VER:-3.4.1}
         - PYTHON_VER=${PYTHON_VER:-3.10}
-    command: ['/bin/sh', '-c', 'nose2 --verbose -F']
+    command: ['/bin/sh', '-c', 'pip3 install --force-reinstall /plantuml_markdown && /nose2 --verbose -F']
     volumes:
       - .:/plantuml_markdown
-      - ./plantuml_markdown.py:/usr/local/lib/python${PYTHON_VER:-3.10}/site-packages/plantuml_markdown.py
       - ./test:/plantuml-markdown/test

--- a/plantuml_markdown/__init__.py
+++ b/plantuml_markdown/__init__.py
@@ -1,0 +1,4 @@
+
+from .plantuml_markdown import PlantUMLMarkdownExtension, makeExtension
+__all__ = ["PlantUMLMarkdownExtension","makeExtension"]
+

--- a/plantuml_markdown/plantuml_markdown.py
+++ b/plantuml_markdown/plantuml_markdown.py
@@ -75,6 +75,7 @@ from requests.adapters import HTTPAdapter, Retry, Response
 from xml.etree import ElementTree as etree
 
 
+
 # use markdown_py with -v to enable warnings, or with --noisy to enable debug logs
 logger = logging.getLogger('MARKDOWN')
 plantuml_alphabet = string.digits + string.ascii_uppercase + string.ascii_lowercase + '-_'
@@ -666,6 +667,7 @@ class PlantUMLMarkdownExtension(markdown.Extension):
         super(PlantUMLMarkdownExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md):
+        md.registerExtension(self)
         blockprocessor = PlantUMLPreprocessor(md)
         blockprocessor.config = self.getConfigs()
         # need to go before both fenced_code_block and things like retext's PosMapMarkPreprocessor.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'test-requirements.txt')) as f:
 
 setuptools.setup(
     name="plantuml-markdown",
-    version="3.9.3",
+    version="3.9.4",
     author="Michele Tessaro",
     author_email="michele.tessaro.tex@gmail.com",
     description="A PlantUML plugin for Markdown",
@@ -23,9 +23,12 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     keywords=['Markdown', 'typesetting', 'include', 'plugin', 'extension'],
     url="https://github.com/mikitex70/plantuml-markdown",
-    py_modules=['plantuml_markdown'],
+    packages=['plantuml_markdown'],
     install_requires=install_requirements,
     tests_require=test_requirements,
+    entry_points={
+        'markdown.extensions': ['plantuml_markdown = plantuml_markdown:PlantUMLMarkdownExtension']
+    },
     classifiers=[
         "Programming Language :: Python",
         "License :: OSI Approved :: BSD License",

--- a/test/test_plantuml.py
+++ b/test/test_plantuml.py
@@ -157,7 +157,7 @@ class PlantumlTest(TestCase):
             f.write('A --> B')
 
         # from test.markdown_builder import MarkdownBuilder
-        from plantuml_markdown import PlantUMLPreprocessor
+        from plantuml_markdown.plantuml_markdown import PlantUMLPreprocessor
 
         # mocking a method to capture the generated PlantUML source code
         with mock.patch.object(PlantUMLPreprocessor, '_render_diagram',


### PR DESCRIPTION
the package registers itself as an extension from its pip installed location - It certainly works properly when used as a MkDocs markdown plugin - I have not tested it in other situations, but I think that I have made using the package look syntactically like using the previous module.