### PR TITLE
Bugfix: Don't add newlines in included files, fixes plantuml json support

### DIFF
--- a/plantuml_markdown/plantuml_markdown.py
+++ b/plantuml_markdown/plantuml_markdown.py
@@ -553,9 +553,9 @@ class PlantUMLIncluder:
             if match:
                 # variable definition, save the mapping as the value can be used in !include directives
                 self._definitions[match.group('varname')] = match.group('value')
-                result.append(line)
+                result.append(line_striped)
             elif line_striped.startswith("!include"):
-                result.append(self._readInclLine(line_striped, directory))
+                result.append(self._readInclLine(line_striped, directory).strip())
             elif line_striped.startswith("@start"):
                 # remove startuml as plantuml POST method doesn't like it in include files
                 # we will wrap the whole combined text between start and end tags at the end
@@ -566,7 +566,7 @@ class PlantUMLIncluder:
                 # we will wrap the whole combined text between start and end tags at the end
                 continue
             else:
-                result.append(line)
+                result.append(line_striped)
 
         return result
 


### PR DESCRIPTION
Currently the PlantumlIncluder adds the raw line (contains the line ending) to a list and then joins all those lines with extra newlines.
This results in a blank line between each line.

Plantuml cannot parse some constructs (e.g. json variables) when there are blank lines in them.

With this PR, only stripped lines are added to the list, then joined by newlines, so no blank lines are added.

Examples of the problem:

Json parses correctly: https://www.plantuml.com/plantuml/uml/SoWkIImgAStDuL9KoIhEpuilIynHi5Mevb800gNir4ebAmKbe5XfgX9NBHTNeeAUdK8IbqDgNWfG3m00
Blank line causes json parsing to break: https://www.plantuml.com/plantuml/uml/SoWkIImgAStDuL9KoIhEpuilIynHi5Mevk9I00AbxDHA9Ii59Q1WQQeILoqNLwA2dfr24fT3QbuAK1C0