### PR TITLE
chore: include test-requirements.txt in the release.sh and resulting tarball, so that hermetic (dependencies cached offline) builds don't fail

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,8 +11,8 @@ python setup.py bdist_wheel sdist --formats tar
 pushd dist >/dev/null || exit
     distrib=$(ls *.tar); distrib=${distrib/.tar/}
     mkdir -p ${distrib}
-        cp ../requirements.txt ${distrib}
-        tar rvf ${distrib}.tar ${distrib}/requirements.txt && gzip ${distrib}.tar
+        cp ../requirements.txt ../test-requirements.txt ${distrib}
+        tar rvf ${distrib}.tar ${distrib}/requirements.txt ${distrib}/test-requirements.txt && gzip ${distrib}.tar
     rm -fr ${distrib}
 popd >/dev/null || exit
 


### PR DESCRIPTION
chore: include test-requirements.txt in the release.sh and resulting tarball, so that hermetic (dependencies cached offline) builds don't fail
